### PR TITLE
Remove unused System.Threading.Tasks import

### DIFF
--- a/WoofWare.Zoomies.Test/MockWorld.fs
+++ b/WoofWare.Zoomies.Test/MockWorld.fs
@@ -1,7 +1,6 @@
 namespace WoofWare.Zoomies.Test
 
 open System.Collections.Concurrent
-open System.Threading.Tasks
 
 type MockWorld =
     {


### PR DESCRIPTION
Remove unused import from MockWorld.fs test infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)