### PR TITLE
Add OrderedSet collection type with tests

### DIFF
--- a/WoofWare.Zoomies.Test/TestOrderedSet.fs
+++ b/WoofWare.Zoomies.Test/TestOrderedSet.fs
@@ -1,0 +1,91 @@
+namespace WoofWare.Zoomies.Test
+
+open NUnit.Framework
+open FsCheck
+open WoofWare.Zoomies
+
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestOrderedSet =
+    [<Test>]
+    let ``adding duplicate items does not increase count`` () =
+        let property (items : int list) =
+            let set = OrderedSet<int> ()
+            items |> List.iter (fun x -> set.Add (x) |> ignore<bool>)
+            let distinctItems = items |> List.distinct
+            set.Count = distinctItems.Length
+
+        Check.One (propConfig, property)
+
+    [<Test>]
+    let ``items appear in insertion order`` () =
+        let property (items : int list) =
+            let set = OrderedSet<int> ()
+            items |> List.iter (fun x -> set.Add (x) |> ignore<bool>)
+
+            let expected = items |> List.distinct
+            let actual = set.ToSeq () |> Seq.toList
+
+            expected = actual
+
+        Check.One (propConfig, property)
+
+    [<Test>]
+    let ``contains returns true for added items`` () =
+        let property (items : int list) =
+            let set = OrderedSet<int> ()
+            items |> List.iter (fun x -> set.Add (x) |> ignore<bool>)
+            items |> List.forall (fun x -> set.Contains (x))
+
+        Check.One (propConfig, property)
+
+    [<Test>]
+    let ``contains returns false for items not added`` () =
+        let property (added : int list) (notAdded : int list) =
+            let set = OrderedSet<int> ()
+            added |> List.iter (fun x -> set.Add (x) |> ignore<bool>)
+
+            let notAddedDistinct =
+                notAdded |> List.filter (fun x -> not (List.contains x added))
+
+            notAddedDistinct |> List.forall (fun x -> not (set.Contains (x)))
+
+        Check.One (propConfig, property)
+
+    [<Test>]
+    let ``add returns true for new items and false for duplicates`` () =
+        let property (items : int list) =
+            let set = OrderedSet<int> ()
+            let mutable seen = Set.empty
+
+            items
+            |> List.forall (fun x ->
+                let wasAdded = set.Add (x)
+                let shouldAdd = not (Set.contains x seen)
+                seen <- Set.add x seen
+                wasAdded = shouldAdd
+            )
+
+        Check.One (propConfig, property)
+
+    [<Test>]
+    let ``indexed access matches insertion order`` () =
+        let property (item1 : int) (items : int list) =
+            let items = item1 :: items
+
+            let set = OrderedSet<int> ()
+            items |> List.iter (fun x -> set.Add (x) |> ignore<bool>)
+            let expected = items |> List.distinct
+            [ 0 .. expected.Length - 1 ] |> List.forall (fun i -> set.[i] = expected.[i])
+
+        Check.One (propConfig, property)
+
+    [<Test>]
+    let ``clear removes all items`` () =
+        let property (items : int list) =
+            let set = OrderedSet<int> ()
+            items |> List.iter (fun x -> set.Add (x) |> ignore<bool>)
+            set.Clear ()
+            set.Count = 0 && (items |> List.forall (fun x -> not (set.Contains (x))))
+
+        Check.One (propConfig, property)

--- a/WoofWare.Zoomies.Test/WoofWare.Zoomies.Test.fsproj
+++ b/WoofWare.Zoomies.Test/WoofWare.Zoomies.Test.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="ConsoleHarness.fs" />
     <Compile Include="CtrlCHandler.fs" />
     <Compile Include="MockWorld.fs" />
+    <Compile Include="TestOrderedSet.fs" />
     <Compile Include="TestRender.fs" />
     <Compile Include="TestFocusCycle.fs" />
     <Compile Include="TestWorldFreezer.fs" />

--- a/WoofWare.Zoomies/OrderedSet.fs
+++ b/WoofWare.Zoomies/OrderedSet.fs
@@ -1,0 +1,36 @@
+namespace WoofWare.Zoomies
+
+type internal OrderedSet<'T when 'T : equality> (capacity : int) =
+    let items = ResizeArray<'T> (capacity)
+    let membership = System.Collections.Generic.HashSet<'T> (capacity)
+
+    // default ResizeArray capacity
+    new () = OrderedSet (4)
+
+    /// Returns `true` if addition was successful, or `false` if we didn't add because the element was already present.
+    member _.Add (item : 'T) : bool =
+        if membership.Add (item) then
+            items.Add (item)
+            true
+        else
+            false
+
+    member _.Contains (item : 'T) : bool = membership.Contains (item)
+
+    member _.Count : int = items.Count
+
+    member _.Item
+        with get (index : int) : 'T = items.[index]
+
+    member _.ToSeq () : seq<'T> = items :> seq<'T>
+
+    member _.Clear () : unit =
+        items.Clear ()
+        membership.Clear ()
+
+    interface System.Collections.Generic.IEnumerable<'T> with
+        member this.GetEnumerator () = this.ToSeq().GetEnumerator ()
+
+    interface System.Collections.IEnumerable with
+        member this.GetEnumerator () =
+            this.ToSeq().GetEnumerator () :> System.Collections.IEnumerator

--- a/WoofWare.Zoomies/WoofWare.Zoomies.fsproj
+++ b/WoofWare.Zoomies/WoofWare.Zoomies.fsproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <Compile Include="Object.fs" />
     <Compile Include="Exception.fs" />
+    <Compile Include="OrderedSet.fs" />
     <Compile Include="ConsoleModifiers.fs" />
     <Compile Include="Nursery.fs" />
     <Compile Include="Vdom.fs" />


### PR DESCRIPTION
- Implement OrderedSet: insertion-ordered set with O(1) add/contains
- Add comprehensive FsCheck property-based tests
- Update test project file to include TestOrderedSet.fs

This data structure is needed for tracking focusable elements in tree order while maintaining efficient lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)