### PR TITLE
Initial focus tracking

### DIFF
--- a/WoofWare.Zoomies.Test/TestRender.fs
+++ b/WoofWare.Zoomies.Test/TestRender.fs
@@ -465,3 +465,133 @@ This is focusable text                                                          
                 return ConsoleHarness.toString terminal
             }
         }
+
+    [<Test>]
+    let ``initial focus is respected`` () =
+        task {
+            let console, terminal = ConsoleHarness.make' (fun () -> 80) (fun () -> 3)
+
+            let world = MockWorld.make ()
+
+            use worldFreezer =
+                WorldFreezer.listen'
+                    UnrecognisedEscapeCodeBehaviour.Throw
+                    StopwatchMock.Empty
+                    world.KeyAvailable
+                    world.ReadKey
+
+            let vdom (previousTickRenderState : RenderState) () =
+                let currentFocus = RenderState.focusedKey previousTickRenderState
+                let checkbox1Key = NodeKey.make "checkbox1"
+                let checkbox2Key = NodeKey.make "checkbox2"
+                let checkbox3Key = NodeKey.make "checkbox3"
+
+                let checkbox1 =
+                    Vdom.checkbox (currentFocus = Some checkbox1Key) false
+                    |> Vdom.withKey checkbox1Key
+                    |> Vdom.withFocusTracking
+
+                let checkbox2 =
+                    Vdom.checkbox (currentFocus = Some checkbox2Key) false
+                    |> Vdom.withKey checkbox2Key
+                    |> fun v -> Vdom.withFocusTracking (v, isInitialFocus = true)
+
+                let checkbox3 =
+                    Vdom.checkbox (currentFocus = Some checkbox3Key) false
+                    |> Vdom.withKey checkbox3Key
+                    |> Vdom.withFocusTracking
+
+                Vdom.panelSplitProportion (
+                    Direction.Vertical,
+                    0.33,
+                    checkbox1,
+                    Vdom.panelSplitProportion (Direction.Vertical, 0.5, checkbox2, checkbox3)
+                )
+
+            let processWorld =
+                { new WorldProcessor<unit, unit> with
+                    member _.ProcessWorld (worldChanges, _, _) =
+                        for change in worldChanges do
+                            match change with
+                            | Keystroke _ -> ()
+                            | KeyboardEvent _ -> failwith "no keyboard events"
+                            | MouseEvent _ -> failwith "no mouse events"
+                            | ApplicationEvent () -> failwith "no app events"
+                            | ApplicationEventException _ -> failwith "no exceptions possible"
+                }
+
+            let renderState = RenderState.make' console
+
+            App.pumpOnce worldFreezer () (fun _ -> true) renderState processWorld vdom
+
+            expect {
+                snapshot
+                    @"
+                                                                                |
+             ☐                         ☐                          ☐             |
+                                                                                |
+"
+
+                return ConsoleHarness.toString terminal
+            }
+
+            // Tab should focus checkbox2 (marked with isInitialFocus=true), not checkbox1
+            world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
+            App.pumpOnce worldFreezer () (fun _ -> true) renderState processWorld vdom
+
+            expect {
+                snapshot
+                    @"
+                                                                                |
+             ☐                        [☐]                         ☐             |
+                                                                                |
+"
+
+                return ConsoleHarness.toString terminal
+            }
+
+            // Tab again should cycle to checkbox3
+            world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
+            App.pumpOnce worldFreezer () (fun _ -> true) renderState processWorld vdom
+
+            expect {
+                snapshot
+                    @"
+                                                                                |
+             ☐                         ☐                         [☐]            |
+                                                                                |
+"
+
+                return ConsoleHarness.toString terminal
+            }
+
+            // Tab again should cycle to checkbox1
+            world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
+            App.pumpOnce worldFreezer () (fun _ -> true) renderState processWorld vdom
+
+            expect {
+                snapshot
+                    @"
+                                                                                |
+            [☐]                        ☐                          ☐             |
+                                                                                |
+"
+
+                return ConsoleHarness.toString terminal
+            }
+
+            // Tab again should cycle back to checkbox2
+            world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
+            App.pumpOnce worldFreezer () (fun _ -> true) renderState processWorld vdom
+
+            expect {
+                snapshot
+                    @"
+                                                                                |
+             ☐                        [☐]                         ☐             |
+                                                                                |
+"
+
+                return ConsoleHarness.toString terminal
+            }
+        }

--- a/WoofWare.Zoomies/Render.fs
+++ b/WoofWare.Zoomies/Render.fs
@@ -89,10 +89,8 @@ module RenderState =
         | None ->
             // No current focus, use initial focus key if available, otherwise first focusable element
             match s.InitialFocusKey with
-            | Some initialKey when s.FocusableKeys.Contains initialKey ->
-                s.FocusedKey <- Some initialKey
-            | _ ->
-                s.FocusedKey <- Some s.FocusableKeys.[0]
+            | Some initialKey when s.FocusableKeys.Contains initialKey -> s.FocusedKey <- Some initialKey
+            | _ -> s.FocusedKey <- Some s.FocusableKeys.[0]
         | Some currentKey ->
             // Find the current key in the list and move to the next one
             match s.FocusableKeys |> Seq.tryFindIndex ((=) currentKey) with
@@ -102,10 +100,8 @@ module RenderState =
             | None ->
                 // Current key is not in the focusable list, use initial focus key if available
                 match s.InitialFocusKey with
-                | Some initialKey when s.FocusableKeys.Contains initialKey ->
-                    s.FocusedKey <- Some initialKey
-                | _ ->
-                    s.FocusedKey <- Some s.FocusableKeys.[0]
+                | Some initialKey when s.FocusableKeys.Contains initialKey -> s.FocusedKey <- Some initialKey
+                | _ -> s.FocusedKey <- Some s.FocusableKeys.[0]
 
     let make' (c : IConsole) =
         let width = c.WindowWidth ()
@@ -317,8 +313,12 @@ module Render =
                 setAtRelativeOffset dirty bounds x y (ValueSome (TerminalCell.OfChar ' '))
 
         let bounds1, bounds2 = splitBounds dir proportion bounds
-        let rendered1 = layoutEither dirty keyToNode focusableKeys initialFocusKey None bounds1 child1
-        let rendered2 = layoutEither dirty keyToNode focusableKeys initialFocusKey None bounds2 child2
+
+        let rendered1 =
+            layoutEither dirty keyToNode focusableKeys initialFocusKey None bounds1 child1
+
+        let rendered2 =
+            layoutEither dirty keyToNode focusableKeys initialFocusKey None bounds2 child2
 
         {
             Bounds = bounds
@@ -367,7 +367,9 @@ module Render =
             setAtRelativeOffset dirty bounds (bounds.Width - 1) i (ValueSome (TerminalCell.OfChar '│'))
 
         let children =
-            [ layoutEither dirty keyToNode focusableKeys initialFocusKey None (shrinkBounds bounds) child ]
+            [
+                layoutEither dirty keyToNode focusableKeys initialFocusKey None (shrinkBounds bounds) child
+            ]
 
         {
             Bounds = bounds
@@ -424,7 +426,14 @@ module Render =
                     | _ -> None
 
                 let rendered =
-                    layout dirty keyToNode focusableKeys initialFocusKey previousRender bounds (Vdom.Unkeyed (unkeyedVdom, Teq.refl))
+                    layout
+                        dirty
+                        keyToNode
+                        focusableKeys
+                        initialFocusKey
+                        previousRender
+                        bounds
+                        (Vdom.Unkeyed (unkeyedVdom, Teq.refl))
 
                 keyToNode.[nodeKey] <- rendered
 
@@ -514,7 +523,17 @@ module Render =
                             child2
                             unkeyedVdom
                 | _ ->
-                    freshRenderPanelSplit keyToNode focusableKeys initialFocusKey dirty bounds dir proportion child1 child2 unkeyedVdom
+                    freshRenderPanelSplit
+                        keyToNode
+                        focusableKeys
+                        initialFocusKey
+                        dirty
+                        bounds
+                        dir
+                        proportion
+                        child1
+                        child2
+                        unkeyedVdom
 
             | UnkeyedVdom.Checkbox (isChecked, focus) ->
                 match previousRender with
@@ -584,7 +603,14 @@ module Render =
                     | _ -> None
 
                 let child =
-                    layout dirty keyToNode focusableKeys initialFocusKey childPreviousRender bounds (Vdom.Keyed (keyedVdom, Teq.refl))
+                    layout
+                        dirty
+                        keyToNode
+                        focusableKeys
+                        initialFocusKey
+                        childPreviousRender
+                        bounds
+                        (Vdom.Keyed (keyedVdom, Teq.refl))
 
                 {
                     Bounds = bounds
@@ -592,7 +618,8 @@ module Render =
                     VDomSource = unkeyedVdom |> KeylessVdom.Unkeyed
                     Self =
                         match child.Self with
-                        | KeylessVdom.Keyed child -> UnkeyedVdom.Focusable (isInitialFocus, child) |> KeylessVdom.Unkeyed
+                        | KeylessVdom.Keyed child ->
+                            UnkeyedVdom.Focusable (isInitialFocus, child) |> KeylessVdom.Unkeyed
                         | KeylessVdom.Unkeyed _ -> failwith "logic error: child is keyed"
                 }
 

--- a/WoofWare.Zoomies/Vdom.fs
+++ b/WoofWare.Zoomies/Vdom.fs
@@ -29,7 +29,7 @@ type private UnkeyedVdom<'bounds> =
     | PanelSplit of Direction * Choice<float, int> * child1 : KeylessVdom<'bounds> * child2 : KeylessVdom<'bounds>
     | TextContent of string * focused : bool
     | Checkbox of isChecked : bool * isFocused : bool
-    | Focusable of KeyedVdom<'bounds>
+    | Focusable of isInitialFocus : bool * KeyedVdom<'bounds>
 
 and private KeyedVdom<'bounds> = | WithKey of NodeKey * UnkeyedVdom<'bounds>
 
@@ -228,11 +228,16 @@ type Vdom =
     /// When the user hits TAB while automatic focus tracking is enabled, the WoofWare.Zoomies framework will
     /// cycle through tree nodes which are `focusable`.
     ///
+    /// If `isInitialFocus` is true, this node will receive focus first when the system needs to select an initial
+    /// focus target (e.g., on first render or when no focusable node currently has focus).
+    /// At most one node should have `isInitialFocus = true` in a given VDOM tree.
+    ///
     /// This annotation does nothing if WoofWare.Zoomies is running with automatic focus tracking turned off.
-    static member withFocusTracking (vdom : Vdom<'bounds, Keyed>) : Vdom<'bounds, Unkeyed> =
+    static member withFocusTracking (vdom : Vdom<'bounds, Keyed>, ?isInitialFocus : bool) : Vdom<'bounds, Unkeyed> =
+        let isInitialFocus = defaultArg isInitialFocus false
         match vdom with
         | Unkeyed (_, teq) -> VdomUtils.teqUnreachable teq
-        | Keyed (vdom, _) -> Vdom.Unkeyed (UnkeyedVdom.Focusable vdom, Teq.refl)
+        | Keyed (vdom, _) -> Vdom.Unkeyed (UnkeyedVdom.Focusable (isInitialFocus, vdom), Teq.refl)
 
 [<Sealed>]
 type private KeylessVdom =

--- a/WoofWare.Zoomies/Vdom.fs
+++ b/WoofWare.Zoomies/Vdom.fs
@@ -235,6 +235,7 @@ type Vdom =
     /// This annotation does nothing if WoofWare.Zoomies is running with automatic focus tracking turned off.
     static member withFocusTracking (vdom : Vdom<'bounds, Keyed>, ?isInitialFocus : bool) : Vdom<'bounds, Unkeyed> =
         let isInitialFocus = defaultArg isInitialFocus false
+
         match vdom with
         | Unkeyed (_, teq) -> VdomUtils.teqUnreachable teq
         | Keyed (vdom, _) -> Vdom.Unkeyed (UnkeyedVdom.Focusable (isInitialFocus, vdom), Teq.refl)


### PR DESCRIPTION
Add optional `isInitialFocus` parameter to `Vdom.withFocusTracking` to allow
specifying which focusable element should receive focus first when the system
needs to select an initial focus target (e.g., on first render or when Tab is
pressed with no current focus).

Changes:
- Add `isInitialFocus` bool parameter to `UnkeyedVdom.Focusable` union case
- Update `Vdom.withFocusTracking` to accept optional `?isInitialFocus` parameter
- Add `InitialFocusKey` field to `RenderState` to track the marked initial focus key
- Modify `advanceFocus` to use initial focus key when no current focus exists
- Thread `initialFocusKey` ref through layout functions to capture the marked key