### PR TITLE
Refactor user state to be immutable, and implement aggressive early cutoff

### DIFF
--- a/WoofWare.Zoomies.App/Program.fs
+++ b/WoofWare.Zoomies.App/Program.fs
@@ -59,7 +59,9 @@ module FileBrowser =
                         // ignore keyboard events
                         ()
                     | WorldStateChange.Keystroke key when key.KeyChar = ' ' ->
-                        // Toggle which file we're showing
+                        // Toggle which file we're showing.
+                        // Just to keep the code smaller, we do this in a pretty dumb way; you might want to
+                        // go for MORE EFFICIENCY by having some efficient mutable intermediate representation.
                         newState <-
                             { newState with
                                 ShowingFile1 = not newState.ShowingFile1

--- a/WoofWare.Zoomies.App/Program.fs
+++ b/WoofWare.Zoomies.App/Program.fs
@@ -101,7 +101,7 @@ module FileBrowser =
             let label = $"[{state.File1Path}] / [{state.File2Path}]"
 
             let checkboxKey = NodeKey.make "checkbox"
-            let currentFocus = vdomContext.FocusedKey
+            let currentFocus = VdomContext.focusedKey vdomContext
 
             let checkbox =
                 Vdom.checkbox (currentFocus = Some checkboxKey) (not state.ShowingFile1)

--- a/WoofWare.Zoomies.App/Program.fs
+++ b/WoofWare.Zoomies.App/Program.fs
@@ -61,11 +61,10 @@ module FileBrowser =
                     | WorldStateChange.Keystroke key when key.KeyChar = ' ' ->
                         // Toggle which file we're showing
                         newState <-
-                            {
-                                newState with
-                                    ShowingFile1 = not newState.ShowingFile1
-                                    IsLoading = true
-                                    FileContent = None
+                            { newState with
+                                ShowingFile1 = not newState.ShowingFile1
+                                IsLoading = true
+                                FileContent = None
                             }
                         // Trigger async load of the new file
                         loadFileAsync worldBridge newState.CurrentFile
@@ -75,19 +74,17 @@ module FileBrowser =
                         // Only update if this is still the file we're expecting
                         if filename = newState.CurrentFile then
                             newState <-
-                                {
-                                    newState with
-                                        FileContent = Some content
-                                        IsLoading = false
+                                { newState with
+                                    FileContent = Some content
+                                    IsLoading = false
                                 }
 
                     | WorldStateChange.ApplicationEvent (FileLoadError (filename, error)) ->
                         if filename = newState.CurrentFile then
                             newState <-
-                                {
-                                    newState with
-                                        FileContent = Some $"Error loading file: {error}"
-                                        IsLoading = false
+                                { newState with
+                                    FileContent = Some $"Error loading file: {error}"
+                                    IsLoading = false
                                 }
 
                     | WorldStateChange.ApplicationEventException e ->
@@ -126,7 +123,10 @@ module FileBrowser =
     let run (file1 : string) (file2 : string) =
         let state = State.Create (file1, file2)
 
-        let initialState = { state with IsLoading = true }
+        let initialState =
+            { state with
+                IsLoading = true
+            }
 
         App.run
             initialState

--- a/WoofWare.Zoomies.App/Program.fs
+++ b/WoofWare.Zoomies.App/Program.fs
@@ -96,12 +96,12 @@ module FileBrowser =
                 newState
         }
 
-    let view (renderState : RenderState) (state : State) : Vdom<DesiredBounds, Unkeyed> =
+    let view (vdomContext : VdomContext) (state : State) : Vdom<DesiredBounds, Unkeyed> =
         let topPane =
             let label = $"[{state.File1Path}] / [{state.File2Path}]"
 
             let checkboxKey = NodeKey.make "checkbox"
-            let currentFocus = RenderState.focusedKey renderState
+            let currentFocus = vdomContext.FocusedKey
 
             let checkbox =
                 Vdom.checkbox (currentFocus = Some checkboxKey) (not state.ShowingFile1)

--- a/WoofWare.Zoomies.Test/TestExternalEventSubscription.fs
+++ b/WoofWare.Zoomies.Test/TestExternalEventSubscription.fs
@@ -100,7 +100,7 @@ module TestExternalEventSubscription =
                         newState
                 }
 
-            let vdom (_ : RenderState) (state : TimerState) =
+            let vdom (_ : VdomContext) (state : TimerState) =
                 Vdom.textContent false $"%i{state.Counter}"
 
             let console, terminal = ConsoleHarness.make' (fun () -> 10) (fun () -> 1)

--- a/WoofWare.Zoomies.Test/TestExternalEventSubscription.fs
+++ b/WoofWare.Zoomies.Test/TestExternalEventSubscription.fs
@@ -68,15 +68,26 @@ module TestExternalEventSubscription =
                                 | Some _ -> failwith "only should have got one StartTimer"
 
                                 let subscription = world.SubscribeEvent timer.Elapsed (fun _ -> TimerTick)
-                                newState <- { newState with TimerSubscription = Some subscription }
+
+                                newState <-
+                                    { newState with
+                                        TimerSubscription = Some subscription
+                                    }
 
                             | WorldStateChange.ApplicationEvent StopTimer ->
                                 newState.TimerSubscription |> Option.iter (fun s -> s.Dispose ())
                                 globalTimer |> Option.get :> IDisposable |> _.Dispose()
-                                newState <- { newState with TimerSubscription = None }
+
+                                newState <-
+                                    { newState with
+                                        TimerSubscription = None
+                                    }
 
                             | WorldStateChange.ApplicationEvent TimerTick ->
-                                newState <- { newState with Counter = newState.Counter + 1 }
+                                newState <-
+                                    { newState with
+                                        Counter = newState.Counter + 1
+                                    }
 
                             | WorldStateChange.Keystroke c when c.KeyChar = ' ' ->
                                 // Toggle timer on space

--- a/WoofWare.Zoomies.Test/TestFocusCycle.fs
+++ b/WoofWare.Zoomies.Test/TestFocusCycle.fs
@@ -437,16 +437,18 @@ module TestFocusCycle =
 
             let processWorld =
                 { new WorldProcessor<_, bool> with
-                    member _.ProcessWorld (inputs, _, state) =
+                    member _.ProcessWorld (inputs, _, renderCheckbox1) =
+                        let mutable renderCheckbox1 = renderCheckbox1
+
                         for s in inputs do
                             match s with
-                            | WorldStateChange.Keystroke _ -> ()
+                            | WorldStateChange.Keystroke _ -> renderCheckbox1 <- not renderCheckbox1
                             | WorldStateChange.MouseEvent _ -> failwith "no mouse events"
                             | WorldStateChange.ApplicationEvent () -> failwith "no app events"
                             | WorldStateChange.KeyboardEvent _ -> failwith "no keyboard events"
                             | WorldStateChange.ApplicationEventException _ -> failwith "no exceptions possible"
 
-                        state
+                        renderCheckbox1
                 }
 
             let renderState = RenderState.make' console
@@ -479,8 +481,8 @@ module TestFocusCycle =
                 return ConsoleHarness.toString terminal
             }
 
-            // Now reassign the key to a different element
-            renderCheckbox1 <- false
+            // Now reassign the key to a different element. Trigger a rerender:
+            world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
 
             renderCheckbox1 <-
                 App.pumpOnce worldFreezer renderCheckbox1 haveFrameworkHandleFocus renderState processWorld vdom

--- a/WoofWare.Zoomies.Test/TestFocusCycle.fs
+++ b/WoofWare.Zoomies.Test/TestFocusCycle.fs
@@ -85,7 +85,8 @@ module TestFocusCycle =
             let renderState = RenderState.make' console
             let mutable currentState = state
 
-            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
+            currentState <-
+                App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -98,7 +99,9 @@ module TestFocusCycle =
 
             // Nothing focused, so space does nothing
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
-            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
+
+            currentState <-
+                App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -111,7 +114,9 @@ module TestFocusCycle =
 
             // Move focus to the first focusable element
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
+
+            currentState <-
+                App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -123,7 +128,9 @@ module TestFocusCycle =
             }
 
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
-            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
+
+            currentState <-
+                App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -135,7 +142,9 @@ module TestFocusCycle =
             }
 
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
+
+            currentState <-
+                App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -147,7 +156,9 @@ module TestFocusCycle =
             }
 
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
-            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
+
+            currentState <-
+                App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -159,7 +170,9 @@ module TestFocusCycle =
             }
 
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
+
+            currentState <-
+                App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -171,7 +184,9 @@ module TestFocusCycle =
             }
 
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
-            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
+
+            currentState <-
+                App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -183,7 +198,9 @@ module TestFocusCycle =
             }
 
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
+
+            currentState <-
+                App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -195,7 +212,9 @@ module TestFocusCycle =
             }
 
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
-            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
+
+            currentState <-
+                App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -207,7 +226,9 @@ module TestFocusCycle =
             }
 
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
+
+            currentState <-
+                App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -270,7 +291,8 @@ module TestFocusCycle =
             let renderState = RenderState.make' console
             let mutable currentState = state
 
-            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
+            currentState <-
+                App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -283,7 +305,9 @@ module TestFocusCycle =
 
             // Tab to focus first checkbox
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
+
+            currentState <-
+                App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -296,7 +320,9 @@ module TestFocusCycle =
 
             // Tab to focus second checkbox
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
+
+            currentState <-
+                App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -309,7 +335,9 @@ module TestFocusCycle =
 
             // Shift+Tab to go back to first checkbox
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, true, false, false))
-            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
+
+            currentState <-
+                App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -322,7 +350,9 @@ module TestFocusCycle =
 
             // Shift+Tab from first should wrap to last
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, true, false, false))
-            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
+
+            currentState <-
+                App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -335,7 +365,9 @@ module TestFocusCycle =
 
             // Check the last checkbox
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
-            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
+
+            currentState <-
+                App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -348,7 +380,9 @@ module TestFocusCycle =
 
             // Shift+Tab to third checkbox
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, true, false, false))
-            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
+
+            currentState <-
+                App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -419,7 +453,8 @@ module TestFocusCycle =
             let renderState = RenderState.make' console
             let mutable renderCheckbox1 = true
 
-            renderCheckbox1 <- App.pumpOnce worldFreezer renderCheckbox1 haveFrameworkHandleFocus renderState processWorld vdom
+            renderCheckbox1 <-
+                App.pumpOnce worldFreezer renderCheckbox1 haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -432,7 +467,9 @@ module TestFocusCycle =
 
             // Tab to focus the checkbox
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            renderCheckbox1 <- App.pumpOnce worldFreezer renderCheckbox1 haveFrameworkHandleFocus renderState processWorld vdom
+
+            renderCheckbox1 <-
+                App.pumpOnce worldFreezer renderCheckbox1 haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -445,7 +482,9 @@ module TestFocusCycle =
 
             // Now reassign the key to a different element
             renderCheckbox1 <- false
-            renderCheckbox1 <- App.pumpOnce worldFreezer renderCheckbox1 haveFrameworkHandleFocus renderState processWorld vdom
+
+            renderCheckbox1 <-
+                App.pumpOnce worldFreezer renderCheckbox1 haveFrameworkHandleFocus renderState processWorld vdom
 
             // Focus should remain on the element with shared-key, even though it's a different element
             expect {
@@ -521,7 +560,8 @@ module TestFocusCycle =
             let mutable renderFocusable = ref 0
             let renderState = RenderState.make' console
 
-            renderFocusable <- App.pumpOnce worldFreezer renderFocusable haveFrameworkHandleFocus renderState processWorld vdom
+            renderFocusable <-
+                App.pumpOnce worldFreezer renderFocusable haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -534,7 +574,9 @@ module TestFocusCycle =
 
             // Tab to focus the checkbox
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            renderFocusable <- App.pumpOnce worldFreezer renderFocusable haveFrameworkHandleFocus renderState processWorld vdom
+
+            renderFocusable <-
+                App.pumpOnce worldFreezer renderFocusable haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -547,7 +589,9 @@ module TestFocusCycle =
 
             // Now reassign the key to a non-focusable element
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
-            renderFocusable <- App.pumpOnce worldFreezer renderFocusable haveFrameworkHandleFocus renderState processWorld vdom
+
+            renderFocusable <-
+                App.pumpOnce worldFreezer renderFocusable haveFrameworkHandleFocus renderState processWorld vdom
 
             // The element is no longer in the focusable list.
             // Vdom construction sees that on the previous tick, that element was focused, so it displays as focused.
@@ -562,7 +606,9 @@ more       [☐]  |
 
             // Give us a rerender and observe that on the previous tick, nothing was focused according to the framework
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
-            renderFocusable <- App.pumpOnce worldFreezer renderFocusable haveFrameworkHandleFocus renderState processWorld vdom
+
+            renderFocusable <-
+                App.pumpOnce worldFreezer renderFocusable haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot

--- a/WoofWare.Zoomies.Test/TestFocusCycle.fs
+++ b/WoofWare.Zoomies.Test/TestFocusCycle.fs
@@ -20,8 +20,8 @@ module TestFocusCycle =
     let tearDown () =
         GlobalBuilderConfig.updateAllSnapshots ()
 
-    let vdom (previousTickRenderState : RenderState) (checkboxes : bool ImmutableArray) =
-        let currentFocus = RenderState.focusedKey previousTickRenderState
+    let vdom (vdomContext : VdomContext) (checkboxes : bool ImmutableArray) =
+        let currentFocus = vdomContext.FocusedKey
 
         List.init
             4
@@ -60,7 +60,7 @@ module TestFocusCycle =
                             match s with
                             | WorldStateChange.Keystroke c ->
                                 if c.KeyChar = ' ' then
-                                    match RenderState.focusedKey renderState with
+                                    match renderState.FocusedKey with
                                     | None ->
                                         // pressed space while nothing focused
                                         ()
@@ -267,7 +267,7 @@ module TestFocusCycle =
                             match s with
                             | WorldStateChange.Keystroke c ->
                                 if c.KeyChar = ' ' then
-                                    match RenderState.focusedKey renderState with
+                                    match renderState.FocusedKey with
                                     | None -> ()
                                     | Some focused ->
                                         let key = NodeKey.toString focused
@@ -411,8 +411,8 @@ module TestFocusCycle =
             // State tracks which element to render at a given key
             let haveFrameworkHandleFocus _ = true
 
-            let vdom (previousTickRenderState : RenderState) (renderCheckbox1 : bool) =
-                let currentFocus = RenderState.focusedKey previousTickRenderState
+            let vdom (vdomContext : VdomContext) (renderCheckbox1 : bool) =
+                let currentFocus = vdomContext.FocusedKey
                 let sharedKey = NodeKey.make "shared-key"
 
                 if renderCheckbox1 then
@@ -504,8 +504,8 @@ module TestFocusCycle =
 
             let world = MockWorld.make ()
 
-            let vdom (previousTickRenderState : RenderState) (tick : int) =
-                let currentFocus = RenderState.focusedKey previousTickRenderState
+            let vdom (vdomContext : VdomContext) (tick : int) =
+                let currentFocus = vdomContext.FocusedKey
                 let sharedKey = NodeKey.make "shared-key"
 
                 match tick with
@@ -528,7 +528,7 @@ module TestFocusCycle =
                     )
                 | 2 ->
                     // Third frame: nothing should now be focused, because the previous frame had no focusable elements.
-                    RenderState.focusedKey previousTickRenderState |> shouldEqual None
+                    currentFocus |> shouldEqual None
                     Vdom.textContent false ""
                 | _ -> failwith "unexpected"
 

--- a/WoofWare.Zoomies.Test/TestFocusCycle.fs
+++ b/WoofWare.Zoomies.Test/TestFocusCycle.fs
@@ -52,6 +52,8 @@ module TestFocusCycle =
             let processWorld =
                 { new WorldProcessor<_, bool[]> with
                     member _.ProcessWorld (inputs, renderState, checkboxes) =
+                        let mutable newCheckboxes = checkboxes
+
                         for s in inputs do
                             match s with
                             | WorldStateChange.Keystroke c ->
@@ -66,7 +68,8 @@ module TestFocusCycle =
 
                                         if key.StartsWith (prefix, StringComparison.Ordinal) then
                                             let key = key.Substring prefix.Length |> Int32.Parse
-                                            Array.set checkboxes key (Array.get checkboxes key |> not)
+                                            newCheckboxes <- Array.copy newCheckboxes
+                                            Array.set newCheckboxes key (Array.get newCheckboxes key |> not)
                                         else
                                             failwith "unexpected key"
                                 else
@@ -75,10 +78,14 @@ module TestFocusCycle =
                             | WorldStateChange.ApplicationEvent () -> failwith "no app events"
                             | WorldStateChange.KeyboardEvent _ -> failwith "no keyboard events"
                             | WorldStateChange.ApplicationEventException _ -> failwith "no exceptions possible"
+
+                        newCheckboxes
                 }
 
             let renderState = RenderState.make' console
-            App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom
+            let mutable currentState = state
+
+            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -91,7 +98,7 @@ module TestFocusCycle =
 
             // Nothing focused, so space does nothing
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
-            App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom
+            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -104,7 +111,7 @@ module TestFocusCycle =
 
             // Move focus to the first focusable element
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom
+            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -116,7 +123,7 @@ module TestFocusCycle =
             }
 
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
-            App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom
+            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -128,7 +135,7 @@ module TestFocusCycle =
             }
 
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom
+            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -140,7 +147,7 @@ module TestFocusCycle =
             }
 
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
-            App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom
+            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -152,7 +159,7 @@ module TestFocusCycle =
             }
 
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom
+            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -164,7 +171,7 @@ module TestFocusCycle =
             }
 
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
-            App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom
+            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -176,7 +183,7 @@ module TestFocusCycle =
             }
 
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom
+            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -188,7 +195,7 @@ module TestFocusCycle =
             }
 
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
-            App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom
+            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -200,7 +207,7 @@ module TestFocusCycle =
             }
 
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom
+            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -232,6 +239,8 @@ module TestFocusCycle =
             let processWorld =
                 { new WorldProcessor<_, bool[]> with
                     member _.ProcessWorld (inputs, renderState, checkboxes) =
+                        let mutable newCheckboxes = checkboxes
+
                         for s in inputs do
                             match s with
                             | WorldStateChange.Keystroke c ->
@@ -244,7 +253,8 @@ module TestFocusCycle =
 
                                         if key.StartsWith (prefix, StringComparison.Ordinal) then
                                             let key = key.Substring prefix.Length |> Int32.Parse
-                                            Array.set checkboxes key (Array.get checkboxes key |> not)
+                                            newCheckboxes <- Array.copy newCheckboxes
+                                            Array.set newCheckboxes key (Array.get newCheckboxes key |> not)
                                         else
                                             failwith "unexpected key"
                                 else
@@ -253,10 +263,14 @@ module TestFocusCycle =
                             | WorldStateChange.ApplicationEvent () -> failwith "no app events"
                             | WorldStateChange.KeyboardEvent _ -> failwith "no keyboard events"
                             | WorldStateChange.ApplicationEventException _ -> failwith "no exceptions possible"
+
+                        newCheckboxes
                 }
 
             let renderState = RenderState.make' console
-            App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom
+            let mutable currentState = state
+
+            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -269,7 +283,7 @@ module TestFocusCycle =
 
             // Tab to focus first checkbox
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom
+            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -282,7 +296,7 @@ module TestFocusCycle =
 
             // Tab to focus second checkbox
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom
+            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -295,7 +309,7 @@ module TestFocusCycle =
 
             // Shift+Tab to go back to first checkbox
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, true, false, false))
-            App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom
+            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -308,7 +322,7 @@ module TestFocusCycle =
 
             // Shift+Tab from first should wrap to last
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, true, false, false))
-            App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom
+            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -321,7 +335,7 @@ module TestFocusCycle =
 
             // Check the last checkbox
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
-            App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom
+            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -334,7 +348,7 @@ module TestFocusCycle =
 
             // Shift+Tab to third checkbox
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, true, false, false))
-            App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom
+            currentState <- App.pumpOnce worldFreezer currentState haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -363,11 +377,11 @@ module TestFocusCycle =
             // State tracks which element to render at a given key
             let haveFrameworkHandleFocus _ = true
 
-            let vdom (previousTickRenderState : RenderState) (renderCheckbox1 : bool ref) =
+            let vdom (previousTickRenderState : RenderState) (renderCheckbox1 : bool) =
                 let currentFocus = RenderState.focusedKey previousTickRenderState
                 let sharedKey = NodeKey.make "shared-key"
 
-                if renderCheckbox1.Value then
+                if renderCheckbox1 then
                     // First frame: checkbox at shared-key
                     let checkbox1 =
                         Vdom.checkbox (currentFocus = Some sharedKey) false
@@ -389,8 +403,8 @@ module TestFocusCycle =
                     Vdom.panelSplitProportion (SplitDirection.Vertical, 0.5, checkbox1, checkbox2)
 
             let processWorld =
-                { new WorldProcessor<_, bool ref> with
-                    member _.ProcessWorld (inputs, _, _) =
+                { new WorldProcessor<_, bool> with
+                    member _.ProcessWorld (inputs, _, state) =
                         for s in inputs do
                             match s with
                             | WorldStateChange.Keystroke _ -> ()
@@ -398,12 +412,14 @@ module TestFocusCycle =
                             | WorldStateChange.ApplicationEvent () -> failwith "no app events"
                             | WorldStateChange.KeyboardEvent _ -> failwith "no keyboard events"
                             | WorldStateChange.ApplicationEventException _ -> failwith "no exceptions possible"
+
+                        state
                 }
 
             let renderState = RenderState.make' console
-            let renderCheckbox1 = ref true
+            let mutable renderCheckbox1 = true
 
-            App.pumpOnce worldFreezer renderCheckbox1 haveFrameworkHandleFocus renderState processWorld vdom
+            renderCheckbox1 <- App.pumpOnce worldFreezer renderCheckbox1 haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -416,7 +432,7 @@ module TestFocusCycle =
 
             // Tab to focus the checkbox
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            App.pumpOnce worldFreezer renderCheckbox1 haveFrameworkHandleFocus renderState processWorld vdom
+            renderCheckbox1 <- App.pumpOnce worldFreezer renderCheckbox1 haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -428,8 +444,8 @@ module TestFocusCycle =
             }
 
             // Now reassign the key to a different element
-            renderCheckbox1.Value <- false
-            App.pumpOnce worldFreezer renderCheckbox1 haveFrameworkHandleFocus renderState processWorld vdom
+            renderCheckbox1 <- false
+            renderCheckbox1 <- App.pumpOnce worldFreezer renderCheckbox1 haveFrameworkHandleFocus renderState processWorld vdom
 
             // Focus should remain on the element with shared-key, even though it's a different element
             expect {
@@ -489,19 +505,23 @@ module TestFocusCycle =
             let processWorld =
                 { new WorldProcessor<_, int ref> with
                     member _.ProcessWorld (inputs, _, state) =
+                        let mutable newState = state
+
                         for s in inputs do
                             match s with
-                            | WorldStateChange.Keystroke _ -> state.Value <- state.Value + 1
+                            | WorldStateChange.Keystroke _ -> newState <- ref (newState.Value + 1)
                             | WorldStateChange.MouseEvent _ -> failwith "no mouse events"
                             | WorldStateChange.ApplicationEvent () -> failwith "no app events"
                             | WorldStateChange.KeyboardEvent _ -> failwith "no keyboard events"
                             | WorldStateChange.ApplicationEventException _ -> failwith "no exceptions possible"
+
+                        newState
                 }
 
-            let renderFocusable = ref 0
+            let mutable renderFocusable = ref 0
             let renderState = RenderState.make' console
 
-            App.pumpOnce worldFreezer renderFocusable haveFrameworkHandleFocus renderState processWorld vdom
+            renderFocusable <- App.pumpOnce worldFreezer renderFocusable haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -514,7 +534,7 @@ module TestFocusCycle =
 
             // Tab to focus the checkbox
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            App.pumpOnce worldFreezer renderFocusable haveFrameworkHandleFocus renderState processWorld vdom
+            renderFocusable <- App.pumpOnce worldFreezer renderFocusable haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot
@@ -527,7 +547,7 @@ module TestFocusCycle =
 
             // Now reassign the key to a non-focusable element
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
-            App.pumpOnce worldFreezer renderFocusable haveFrameworkHandleFocus renderState processWorld vdom
+            renderFocusable <- App.pumpOnce worldFreezer renderFocusable haveFrameworkHandleFocus renderState processWorld vdom
 
             // The element is no longer in the focusable list.
             // Vdom construction sees that on the previous tick, that element was focused, so it displays as focused.
@@ -542,7 +562,7 @@ more       [☐]  |
 
             // Give us a rerender and observe that on the previous tick, nothing was focused according to the framework
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
-            App.pumpOnce worldFreezer renderFocusable haveFrameworkHandleFocus renderState processWorld vdom
+            renderFocusable <- App.pumpOnce worldFreezer renderFocusable haveFrameworkHandleFocus renderState processWorld vdom
 
             expect {
                 snapshot

--- a/WoofWare.Zoomies.Test/TestFocusCycle.fs
+++ b/WoofWare.Zoomies.Test/TestFocusCycle.fs
@@ -2,7 +2,6 @@ namespace WoofWare.Zoomies.Test
 
 open System
 open System.Collections.Immutable
-open System.Linq
 open FsUnitTyped
 open NUnit.Framework
 open WoofWare.Expect
@@ -21,7 +20,7 @@ module TestFocusCycle =
         GlobalBuilderConfig.updateAllSnapshots ()
 
     let vdom (vdomContext : VdomContext) (checkboxes : bool ImmutableArray) =
-        let currentFocus = vdomContext.FocusedKey
+        let currentFocus = VdomContext.focusedKey vdomContext
 
         List.init
             4
@@ -60,7 +59,7 @@ module TestFocusCycle =
                             match s with
                             | WorldStateChange.Keystroke c ->
                                 if c.KeyChar = ' ' then
-                                    match renderState.FocusedKey with
+                                    match VdomContext.focusedKey renderState with
                                     | None ->
                                         // pressed space while nothing focused
                                         ()
@@ -267,7 +266,7 @@ module TestFocusCycle =
                             match s with
                             | WorldStateChange.Keystroke c ->
                                 if c.KeyChar = ' ' then
-                                    match renderState.FocusedKey with
+                                    match VdomContext.focusedKey renderState with
                                     | None -> ()
                                     | Some focused ->
                                         let key = NodeKey.toString focused
@@ -412,7 +411,7 @@ module TestFocusCycle =
             let haveFrameworkHandleFocus _ = true
 
             let vdom (vdomContext : VdomContext) (renderCheckbox1 : bool) =
-                let currentFocus = vdomContext.FocusedKey
+                let currentFocus = VdomContext.focusedKey vdomContext
                 let sharedKey = NodeKey.make "shared-key"
 
                 if renderCheckbox1 then
@@ -505,7 +504,7 @@ module TestFocusCycle =
             let world = MockWorld.make ()
 
             let vdom (vdomContext : VdomContext) (tick : int) =
-                let currentFocus = vdomContext.FocusedKey
+                let currentFocus = VdomContext.focusedKey vdomContext
                 let sharedKey = NodeKey.make "shared-key"
 
                 match tick with

--- a/WoofWare.Zoomies.Test/TestRender.fs
+++ b/WoofWare.Zoomies.Test/TestRender.fs
@@ -30,7 +30,7 @@ module TestRender =
     let tearDown () =
         GlobalBuilderConfig.updateAllSnapshots ()
 
-    let vdom (previousTickRenderState : RenderState) (state : State) : Vdom<DesiredBounds, _> =
+    let vdom (vdomContext : VdomContext) (state : State) : Vdom<DesiredBounds, _> =
         let left =
             Vdom.textContent
                 false
@@ -46,7 +46,7 @@ module TestRender =
         let topHalf = Vdom.panelSplitProportion (SplitDirection.Vertical, 0.5, left, right)
 
         let toggle1Key = NodeKey.make "toggle1"
-        let currentFocus = RenderState.focusedKey previousTickRenderState
+        let currentFocus = vdomContext.FocusedKey
 
         let bottomHalf =
             Vdom.labelledCheckbox (currentFocus = Some toggle1Key) state.IsToggle1Checked "Press Space to toggle"
@@ -89,11 +89,11 @@ module TestRender =
 
         let renderState = RenderState.make' console
 
-        Render.oneStep renderState state (vdom renderState)
+        Render.oneStep renderState state (vdom (RenderState.vdomContext renderState))
 
         terminalOps.Clear ()
 
-        Render.oneStep renderState state (vdom renderState)
+        Render.oneStep renderState state (vdom (RenderState.vdomContext renderState))
 
         terminalOps |> shouldBeEmpty
 
@@ -102,7 +102,7 @@ module TestRender =
         let processWorld =
             { new WorldProcessor<unit, State> with
                 member _.ProcessWorld (worldChanges, renderState, state) =
-                    let focusedKey = RenderState.focusedKey renderState
+                    let focusedKey = renderState.FocusedKey
                     let mutable newState = state
 
                     for change in worldChanges do
@@ -358,8 +358,8 @@ only displayed when checked                this one is focusable!               
                     world.KeyAvailable
                     world.ReadKey
 
-            let vdom (previousTickRenderState : RenderState) (_ : FakeUnit) =
-                let currentFocus = RenderState.focusedKey previousTickRenderState
+            let vdom (vdomContext : VdomContext) (_ : FakeUnit) =
+                let currentFocus = vdomContext.FocusedKey
                 let textKey = NodeKey.make "focusable-text"
                 let checkboxKey = NodeKey.make "checkbox"
 
@@ -499,8 +499,8 @@ This is focusable text                                                          
                     world.KeyAvailable
                     world.ReadKey
 
-            let vdom (previousTickRenderState : RenderState) (_ : FakeUnit) =
-                let currentFocus = RenderState.focusedKey previousTickRenderState
+            let vdom (vdomContext : VdomContext) (_ : FakeUnit) =
+                let currentFocus = vdomContext.FocusedKey
                 let checkbox1Key = NodeKey.make "checkbox1"
                 let checkbox2Key = NodeKey.make "checkbox2"
                 let checkbox3Key = NodeKey.make "checkbox3"

--- a/WoofWare.Zoomies.Test/TestRender.fs
+++ b/WoofWare.Zoomies.Test/TestRender.fs
@@ -46,7 +46,7 @@ module TestRender =
         let topHalf = Vdom.panelSplitProportion (SplitDirection.Vertical, 0.5, left, right)
 
         let toggle1Key = NodeKey.make "toggle1"
-        let currentFocus = vdomContext.FocusedKey
+        let currentFocus = VdomContext.focusedKey vdomContext
 
         let bottomHalf =
             Vdom.labelledCheckbox (currentFocus = Some toggle1Key) state.IsToggle1Checked "Press Space to toggle"
@@ -102,7 +102,7 @@ module TestRender =
         let processWorld =
             { new WorldProcessor<unit, State> with
                 member _.ProcessWorld (worldChanges, renderState, state) =
-                    let focusedKey = renderState.FocusedKey
+                    let focusedKey = VdomContext.focusedKey renderState
                     let mutable newState = state
 
                     for change in worldChanges do
@@ -359,7 +359,7 @@ only displayed when checked                this one is focusable!               
                     world.ReadKey
 
             let vdom (vdomContext : VdomContext) (_ : FakeUnit) =
-                let currentFocus = vdomContext.FocusedKey
+                let currentFocus = VdomContext.focusedKey vdomContext
                 let textKey = NodeKey.make "focusable-text"
                 let checkboxKey = NodeKey.make "checkbox"
 
@@ -500,7 +500,7 @@ This is focusable text                                                          
                     world.ReadKey
 
             let vdom (vdomContext : VdomContext) (_ : FakeUnit) =
-                let currentFocus = vdomContext.FocusedKey
+                let currentFocus = VdomContext.focusedKey vdomContext
                 let checkbox1Key = NodeKey.make "checkbox1"
                 let checkbox2Key = NodeKey.make "checkbox2"
                 let checkbox3Key = NodeKey.make "checkbox3"

--- a/WoofWare.Zoomies.Test/TestRender.fs
+++ b/WoofWare.Zoomies.Test/TestRender.fs
@@ -6,9 +6,6 @@ open NUnit.Framework
 open WoofWare.Expect
 open WoofWare.Zoomies
 
-[<Struct>]
-type NoState = | NoState
-
 type State =
     {
         IsToggle1Checked : bool
@@ -113,9 +110,15 @@ module TestRender =
                         | Keystroke c when c.KeyChar = ' ' ->
                             match focusedKey with
                             | Some key when key = NodeKey.make "toggle1" ->
-                                newState <- { newState with IsToggle1Checked = not newState.IsToggle1Checked }
+                                newState <-
+                                    { newState with
+                                        IsToggle1Checked = not newState.IsToggle1Checked
+                                    }
                             | Some key when key = NodeKey.make "toggle2" ->
-                                newState <- { newState with IsToggle2Checked = not newState.IsToggle2Checked }
+                                newState <-
+                                    { newState with
+                                        IsToggle2Checked = not newState.IsToggle2Checked
+                                    }
                             | _ -> ()
                         | Keystroke _ -> ()
                         | KeyboardEvent _ -> failwith "no keyboard events"
@@ -355,7 +358,7 @@ only displayed when checked                this one is focusable!               
                     world.KeyAvailable
                     world.ReadKey
 
-            let vdom (previousTickRenderState : RenderState) NoState =
+            let vdom (previousTickRenderState : RenderState) (_ : FakeUnit) =
                 let currentFocus = RenderState.focusedKey previousTickRenderState
                 let textKey = NodeKey.make "focusable-text"
                 let checkboxKey = NodeKey.make "checkbox"
@@ -373,7 +376,7 @@ only displayed when checked                this one is focusable!               
                 Vdom.panelSplitAbsolute (SplitDirection.Horizontal, 3, text, checkbox)
 
             let processWorld =
-                { new WorldProcessor<unit, NoState> with
+                { new WorldProcessor<unit, FakeUnit> with
                     member _.ProcessWorld (worldChanges, _, state) =
                         for change in worldChanges do
                             match change with
@@ -388,7 +391,8 @@ only displayed when checked                this one is focusable!               
 
             let renderState = RenderState.make' console
 
-            App.pumpOnce worldFreezer NoState (fun _ -> true) renderState processWorld vdom |> ignore<NoState>
+            App.pumpOnce worldFreezer (FakeUnit.fake ()) (fun _ -> true) renderState processWorld vdom
+            |> ignore<FakeUnit>
 
             expect {
                 snapshot
@@ -410,7 +414,9 @@ This is focusable text                                                          
 
             // Tab to focus the text
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            App.pumpOnce worldFreezer NoState (fun _ -> true) renderState processWorld vdom |> ignore<NoState>
+
+            App.pumpOnce worldFreezer (FakeUnit.fake ()) (fun _ -> true) renderState processWorld vdom
+            |> ignore<FakeUnit>
 
             expect {
                 snapshot
@@ -432,7 +438,9 @@ This is focusable text                                                          
 
             // Tab to focus the checkbox
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            App.pumpOnce worldFreezer NoState (fun _ -> true) renderState processWorld vdom |> ignore<NoState>
+
+            App.pumpOnce worldFreezer (FakeUnit.fake ()) (fun _ -> true) renderState processWorld vdom
+            |> ignore<FakeUnit>
 
             expect {
                 snapshot
@@ -454,7 +462,9 @@ This is focusable text                                                          
 
             // Tab back to text
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            App.pumpOnce worldFreezer NoState (fun _ -> true) renderState processWorld vdom |> ignore<NoState>
+
+            App.pumpOnce worldFreezer (FakeUnit.fake ()) (fun _ -> true) renderState processWorld vdom
+            |> ignore<FakeUnit>
 
             expect {
                 snapshot
@@ -489,7 +499,7 @@ This is focusable text                                                          
                     world.KeyAvailable
                     world.ReadKey
 
-            let vdom (previousTickRenderState : RenderState) NoState =
+            let vdom (previousTickRenderState : RenderState) (_ : FakeUnit) =
                 let currentFocus = RenderState.focusedKey previousTickRenderState
                 let checkbox1Key = NodeKey.make "checkbox1"
                 let checkbox2Key = NodeKey.make "checkbox2"
@@ -518,7 +528,7 @@ This is focusable text                                                          
                 )
 
             let processWorld =
-                { new WorldProcessor<unit, NoState> with
+                { new WorldProcessor<unit, FakeUnit> with
                     member _.ProcessWorld (worldChanges, _, state) =
                         for change in worldChanges do
                             match change with
@@ -533,7 +543,8 @@ This is focusable text                                                          
 
             let renderState = RenderState.make' console
 
-            App.pumpOnce worldFreezer NoState (fun _ -> true) renderState processWorld vdom |> ignore<NoState>
+            App.pumpOnce worldFreezer (FakeUnit.fake ()) (fun _ -> true) renderState processWorld vdom
+            |> ignore<FakeUnit>
 
             expect {
                 snapshot
@@ -548,7 +559,9 @@ This is focusable text                                                          
 
             // Tab should focus checkbox2 (marked with isInitialFocus=true), not checkbox1
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            App.pumpOnce worldFreezer NoState (fun _ -> true) renderState processWorld vdom |> ignore<NoState>
+
+            App.pumpOnce worldFreezer (FakeUnit.fake ()) (fun _ -> true) renderState processWorld vdom
+            |> ignore<FakeUnit>
 
             expect {
                 snapshot
@@ -563,7 +576,9 @@ This is focusable text                                                          
 
             // Tab again should cycle to checkbox3
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            App.pumpOnce worldFreezer NoState (fun _ -> true) renderState processWorld vdom |> ignore<NoState>
+
+            App.pumpOnce worldFreezer (FakeUnit.fake ()) (fun _ -> true) renderState processWorld vdom
+            |> ignore<FakeUnit>
 
             expect {
                 snapshot
@@ -578,7 +593,9 @@ This is focusable text                                                          
 
             // Tab again should cycle to checkbox1
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            App.pumpOnce worldFreezer NoState (fun _ -> true) renderState processWorld vdom |> ignore<NoState>
+
+            App.pumpOnce worldFreezer (FakeUnit.fake ()) (fun _ -> true) renderState processWorld vdom
+            |> ignore<FakeUnit>
 
             expect {
                 snapshot
@@ -593,7 +610,9 @@ This is focusable text                                                          
 
             // Tab again should cycle back to checkbox2
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            App.pumpOnce worldFreezer NoState (fun _ -> true) renderState processWorld vdom |> ignore<NoState>
+
+            App.pumpOnce worldFreezer (FakeUnit.fake ()) (fun _ -> true) renderState processWorld vdom
+            |> ignore<FakeUnit>
 
             expect {
                 snapshot

--- a/WoofWare.Zoomies/App.fs
+++ b/WoofWare.Zoomies/App.fs
@@ -36,16 +36,13 @@ module App =
                     let mutable start = 0
 
                     while i < changes.Length do
-                        // TODO: make this less grossly inefficient
-                        let vdomContext = RenderState.vdomContext renderState
-
                         match Array.get changes i with
                         | WorldStateChange.Keystroke t when t.Key = ConsoleKey.Tab && t.Modifiers = enum 0 ->
                             if i > 0 then
                                 currentState <-
                                     processWorld.ProcessWorld (
                                         changes.AsSpan().Slice (start, i - 1 - start),
-                                        vdomContext,
+                                        renderState.VdomContext,
                                         currentState
                                     )
 
@@ -62,7 +59,7 @@ module App =
                                 currentState <-
                                     processWorld.ProcessWorld (
                                         changes.AsSpan().Slice (start, i - 1 - start),
-                                        vdomContext,
+                                        renderState.VdomContext,
                                         currentState
                                     )
 
@@ -77,16 +74,13 @@ module App =
                         i <- i + 1
 
                     if start < changes.Length then
-                        let vdomContext = RenderState.vdomContext renderState
-                        processWorld.ProcessWorld (changes.AsSpan().Slice start, vdomContext, currentState)
+                        processWorld.ProcessWorld (changes.AsSpan().Slice start, renderState.VdomContext, currentState)
                     else
                         currentState
                 else
-                    let vdomContext = RenderState.vdomContext renderState
-                    processWorld.ProcessWorld (changes.AsSpan (), vdomContext, state)
+                    processWorld.ProcessWorld (changes.AsSpan (), renderState.VdomContext, state)
 
-        let vdomContext = RenderState.vdomContext renderState
-        Render.oneStep renderState newState (vdom vdomContext)
+        Render.oneStep renderState newState (vdom renderState.VdomContext)
 
         newState
 

--- a/WoofWare.Zoomies/App.fs
+++ b/WoofWare.Zoomies/App.fs
@@ -6,7 +6,8 @@ open System.Threading.Tasks
 
 type WorldProcessor<'appEvent, 'userState> =
     abstract ProcessWorld :
-        events : ReadOnlySpan<WorldStateChange<'appEvent>> * previousRenderState : RenderState * 'userState -> 'userState
+        events : ReadOnlySpan<WorldStateChange<'appEvent>> * previousRenderState : RenderState * 'userState ->
+            'userState
 
 [<RequireQualifiedAccess>]
 module App =

--- a/WoofWare.Zoomies/Render.fs
+++ b/WoofWare.Zoomies/Render.fs
@@ -13,6 +13,17 @@ type Rectangle =
         Height : int
     }
 
+/// Context provided to vdom construction, containing information about the layout of the previous render cycle.
+/// This is immutable and supports structural equality, enabling early cutoff optimizations.
+type VdomContext =
+    {
+        /// The currently focused element's key, if any.
+        /// If you're not using the automatic focus handling mechanism, this is always None.
+        FocusedKey : NodeKey option
+        /// The bounds of the terminal
+        TerminalBounds : Rectangle
+    }
+
 /// So that we can do early cutoff.
 type RenderedNode =
     private
@@ -71,6 +82,13 @@ module RenderState =
 
     /// Query which key had focus in the previous frame, if you're using the automatic focus tracking mechanism.
     let focusedKey (s : RenderState) : NodeKey option = s.FocusedKey
+
+    /// Extract the VdomContext from RenderState for vdom construction.
+    let vdomContext (s : RenderState) : VdomContext =
+        {
+            FocusedKey = s.FocusedKey
+            TerminalBounds = s.TerminalBounds
+        }
 
     /// Query the rendered bounds of a keyed node
     let layoutOf (key : NodeKey) (s : RenderState) : Rectangle option =


### PR DESCRIPTION
The system previously took a mutable user-state parameter and mutated it. This made it very hard to perform early cutoff, because we couldn't tell when the state had mutated so we needed to perform a rerender even if state was unchanged.

Changes:
- WorldProcessor.ProcessWorld now returns new state instead of mutating
- App.pumpOnce threads state through and returns new state
- App.run' uses loop-carried state variable instead of mutation
- Example app uses immutable State record with copy-and-update syntax
- All tests updated to use immutable state and thread state properly
- Early cutoff preventing re-summoning the Vdom function

🤖 Generated with [Claude Code](https://claude.com/claude-code)