### PR TITLE
Fix a race condition in a test

### DIFF
--- a/WoofWare.Zoomies.Test/TestExternalEventSubscription.fs
+++ b/WoofWare.Zoomies.Test/TestExternalEventSubscription.fs
@@ -29,7 +29,7 @@ module TestExternalEventSubscription =
     type MockTimer (_ms : float) =
         let evt = Event<unit> ()
 
-        let mutable disposed =
+        let disposed =
             TaskCompletionSource<unit> TaskCreationOptions.RunContinuationsAsynchronously
 
         [<CLIEvent>]


### PR DESCRIPTION
We were ignoring the Task that submits the disposal request, so we might beat that task to the disposal.