### PR TITLE
Fix Ctrl+C responsiveness during large paste operations

### DIFF
--- a/WoofWare.Zoomies.Test/TestActivationWithPartialBatch.fs
+++ b/WoofWare.Zoomies.Test/TestActivationWithPartialBatch.fs
@@ -107,7 +107,16 @@ module TestActivationWithPartialBatch =
                 }
 
             // Initial render - button is focused
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             // Send a batch of events that will trigger the bug:
             // - 'a' keystroke (will be processed in first batch, then Rerender requested)
@@ -122,7 +131,16 @@ module TestActivationWithPartialBatch =
             world.SendKey (ConsoleKeyInfo ('d', ConsoleKey.NoName, false, false, false))
 
             // Process the batch
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             // Verify that ALL keystrokes were processed (not lost due to the bug)
             // Expected: ['a', 'b', 'c', 'd']
@@ -202,7 +220,16 @@ module TestActivationWithPartialBatch =
                 }
 
             // Initial render
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             // Send: a, b, c, Space (activate), d, e, Space (activate), f
             world.SendKey (ConsoleKeyInfo ('a', ConsoleKey.NoName, false, false, false))
@@ -214,7 +241,16 @@ module TestActivationWithPartialBatch =
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
             world.SendKey (ConsoleKeyInfo ('f', ConsoleKey.NoName, false, false, false))
 
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             // All keystrokes should be processed (note: space keys are consumed by activation, not passed through)
             state.ProcessedKeystrokes |> shouldEqual [ 'a' ; 'b' ; 'c' ; 'd' ; 'e' ; 'f' ]

--- a/WoofWare.Zoomies.Test/TestBatchProcessing.fs
+++ b/WoofWare.Zoomies.Test/TestBatchProcessing.fs
@@ -94,6 +94,7 @@ module TestBatchProcessing =
                         processWorld
                         vdom
                         ActivationResolver.none
+                        (fun () -> false)
 
                 iterations <- iterations + 1
 
@@ -286,6 +287,7 @@ module TestBatchProcessing =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             vdomRenderCount |> shouldEqual 1
 
@@ -303,6 +305,7 @@ module TestBatchProcessing =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             vdomRenderCount |> shouldEqual 2
 
@@ -323,6 +326,7 @@ module TestBatchProcessing =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             vdomRenderCount |> shouldEqual 3
 
@@ -342,6 +346,7 @@ module TestBatchProcessing =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             vdomRenderCount |> shouldEqual 4
 
@@ -363,6 +368,7 @@ module TestBatchProcessing =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             vdomRenderCount |> shouldEqual 5
 
@@ -384,6 +390,7 @@ module TestBatchProcessing =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             vdomRenderCount |> shouldEqual 6
 
@@ -405,6 +412,7 @@ module TestBatchProcessing =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             vdomRenderCount |> shouldEqual 7
 
@@ -483,6 +491,7 @@ module TestBatchProcessing =
                         processWorld
                         vdom
                         ActivationResolver.none
+                        (fun () -> false)
 
                 let initialRenderCount = vdomRenderCount
 
@@ -501,6 +510,7 @@ module TestBatchProcessing =
                         processWorld
                         vdom
                         ActivationResolver.none
+                        (fun () -> false)
 
                 // Verify all events were processed in order
                 let expectedChars = [ 'a' .. char (int 'a' + totalKeystrokes - 1) ]

--- a/WoofWare.Zoomies.Test/TestBordered.fs
+++ b/WoofWare.Zoomies.Test/TestBordered.fs
@@ -115,7 +115,15 @@ module TestBordered =
 
             // First render: fill with X's
             let mutable state =
-                App.pumpOnce worldFreezer false (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    false
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -136,7 +144,15 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX|
             // Second render: show keyed Bordered
             // The border should be drawn, and the X's should be cleared
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -186,7 +202,15 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX|
 
             // First render: long text
             let mutable state =
-                App.pumpOnce worldFreezer true (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    true
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -207,7 +231,15 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX|
             // Second render: short text
             // Border bounds unchanged, child bounds unchanged, but content shrinks
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -261,7 +293,15 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX|
 
             // First render: long text
             let mutable state =
-                App.pumpOnce worldFreezer true (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    true
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -281,7 +321,15 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX|
 
             // Second render: short text
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot

--- a/WoofWare.Zoomies.Test/TestButton.fs
+++ b/WoofWare.Zoomies.Test/TestButton.fs
@@ -84,7 +84,16 @@ module TestButton =
                 }
 
             // Initial render - button unfocused
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -99,7 +108,17 @@ Hello, World!                           |
 
             // Press tab to focus the button
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -114,7 +133,17 @@ Hello, World!                           |
 
             // Press space to activate the button
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -129,7 +158,17 @@ Goodbye, World!                         |
 
             // Press space again to flip back
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -233,7 +272,16 @@ Hello, World!                           |
                 }
 
             // Initial render - Button 1 focused (isFirstToFocus)
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -248,7 +296,17 @@ Last clicked: None                                |
 
             // Activate Button 1 with space
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -263,7 +321,17 @@ Last clicked: Button 1                            |
 
             // Tab to Button 2
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -278,7 +346,17 @@ Last clicked: Button 1                            |
 
             // Activate Button 2 with Enter
             world.SendKey (ConsoleKeyInfo ('\r', ConsoleKey.Enter, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -293,7 +371,17 @@ Last clicked: Button 2                            |
 
             // Tab to Button 3
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -308,7 +396,17 @@ Last clicked: Button 2                            |
 
             // Activate Button 3 with space
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -323,7 +421,17 @@ Last clicked: Button 3                            |
 
             // Tab back to Button 1 (cycles)
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -387,7 +495,16 @@ Last clicked: Button 3                            |
             let mutable state = true
 
             // Initial render - button focused
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -402,7 +519,17 @@ Hello, World!                           |
 
             // Press space to activate the button
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -420,7 +547,16 @@ Goodbye, World!                         |
             clock.Advance (TimeSpan.FromMilliseconds (VdomContext.RECENT_ACTIVATION_TIMEOUT_MS - 0.01))
             |> ignore<DateTime>
 
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -434,7 +570,17 @@ Goodbye, World!                         |
             }
 
             clock.Advance (TimeSpan.FromMilliseconds 0.02) |> ignore<DateTime>
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             expect {
                 snapshot

--- a/WoofWare.Zoomies.Test/TestCheckbox.fs
+++ b/WoofWare.Zoomies.Test/TestCheckbox.fs
@@ -59,6 +59,7 @@ module TestCheckbox =
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             terminalOps.Clear ()
@@ -74,6 +75,7 @@ module TestCheckbox =
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             // Check that the checkbox has bounds with Height=0

--- a/WoofWare.Zoomies.Test/TestCollapsible.fs
+++ b/WoofWare.Zoomies.Test/TestCollapsible.fs
@@ -94,6 +94,7 @@ module TestCollapsible =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -125,6 +126,7 @@ module TestCollapsible =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -156,6 +158,7 @@ module TestCollapsible =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -187,6 +190,7 @@ This stuff was hidden                                       |
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -284,6 +288,7 @@ This stuff was hidden                                       |
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -315,6 +320,7 @@ This stuff was hidden                                       |
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             // Expand
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
@@ -328,6 +334,7 @@ This stuff was hidden                                       |
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -425,6 +432,7 @@ Line 2 of content                                           |
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -456,6 +464,7 @@ Line 2 of content                                           |
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -487,6 +496,7 @@ Line 2 of content                                           |
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot

--- a/WoofWare.Zoomies.Test/TestExternalEventSubscription.fs
+++ b/WoofWare.Zoomies.Test/TestExternalEventSubscription.fs
@@ -122,7 +122,15 @@ module TestExternalEventSubscription =
             let mutable state = TimerState.Empty ()
 
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -137,7 +145,15 @@ module TestExternalEventSubscription =
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
 
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -153,7 +169,15 @@ module TestExternalEventSubscription =
             globalTimer.IsNone |> shouldEqual true
             // But after another pump, we'll process the timer-start.
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             match globalTimer with
             | Some timer -> timer.Trigger ()
@@ -161,7 +185,15 @@ module TestExternalEventSubscription =
 
             // The timer has triggered an app event!
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -177,7 +209,15 @@ module TestExternalEventSubscription =
             | None -> failwith "expected a timer to be running"
 
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -192,7 +232,15 @@ module TestExternalEventSubscription =
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
 
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -217,6 +265,7 @@ module TestExternalEventSubscription =
                         processWorld
                         vdom
                         ActivationResolver.none
+                        (fun () -> false)
 
                 do! timer.Disposal
                 ()

--- a/WoofWare.Zoomies.Test/TestFocusCycle.fs
+++ b/WoofWare.Zoomies.Test/TestFocusCycle.fs
@@ -118,6 +118,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -140,6 +141,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -162,6 +164,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -183,6 +186,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -204,6 +208,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -225,6 +230,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -246,6 +252,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -267,6 +274,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -288,6 +296,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -309,6 +318,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -330,6 +340,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -409,6 +420,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -431,6 +443,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -453,6 +466,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -475,6 +489,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -497,6 +512,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -519,6 +535,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -541,6 +558,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -618,6 +636,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -640,6 +659,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -662,6 +682,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             // Focus should remain on the element with shared-key, even though it's a different element
             expect {
@@ -741,6 +762,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -763,6 +785,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -785,6 +808,7 @@ module TestFocusCycle =
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             // The element is no longer in the focusable list.
             // Vdom construction sees that on the previous tick, that element was focused, so it displays as focused.
@@ -809,6 +833,7 @@ more      [☐]   |
                     processWorld
                     vdom
                     ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -873,6 +898,7 @@ more      [☐]   |
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {
@@ -904,6 +930,7 @@ This is focusable text                                                          
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             // Assert that focus moved to the text element
@@ -938,6 +965,7 @@ This is focusable text                                                          
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             // Assert that focus moved to the checkbox
@@ -972,6 +1000,7 @@ This is focusable text                                                          
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {
@@ -1050,6 +1079,7 @@ This is focusable text                                                          
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {
@@ -1074,6 +1104,7 @@ This is focusable text                                                          
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {
@@ -1098,6 +1129,7 @@ This is focusable text                                                          
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {
@@ -1122,6 +1154,7 @@ This is focusable text                                                          
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {
@@ -1146,6 +1179,7 @@ This is focusable text                                                          
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {
@@ -1218,6 +1252,7 @@ This is focusable text                                                          
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {
@@ -1242,6 +1277,7 @@ This is focusable text                                                          
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {
@@ -1266,6 +1302,7 @@ This is focusable text                                                          
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {
@@ -1290,6 +1327,7 @@ This is focusable text                                                          
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {
@@ -1314,6 +1352,7 @@ This is focusable text                                                          
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {

--- a/WoofWare.Zoomies.Test/TestPanelSplit.fs
+++ b/WoofWare.Zoomies.Test/TestPanelSplit.fs
@@ -116,7 +116,15 @@ module TestPanelSplit =
 
             // First render: fill with X's
             let mutable state =
-                App.pumpOnce worldFreezer false (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    false
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -137,7 +145,15 @@ module TestPanelSplit =
             // Second render: show keyed PanelSplit
             // The X's should be cleared (replaced with spaces), not left as artifacts
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -196,6 +212,7 @@ module TestPanelSplit =
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             // Check that the left child has zero width
@@ -252,6 +269,7 @@ module TestPanelSplit =
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             // Check that the top child has zero height
@@ -303,6 +321,7 @@ module TestPanelSplit =
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {
@@ -365,6 +384,7 @@ Hello world                                                        Hi           
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {
@@ -419,6 +439,7 @@ onger piece text her|
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {
@@ -474,6 +495,7 @@ o   d   |
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {
@@ -532,6 +554,7 @@ e multiple lines when rendered          |
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {
@@ -585,6 +608,7 @@ nt                            |
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {
@@ -640,6 +664,7 @@ nt                            |
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {
@@ -695,7 +720,15 @@ B|
 
             // First render: 50/50 split with X's filling the left side
             let mutable state =
-                App.pumpOnce worldFreezer true (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    true
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -715,7 +748,15 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX                                        
 
             // Second render: 25/75 split with only "AAA" on left
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             // For reference, although the actual test assertion comes afterwards:
             let secondRender = ConsoleHarness.toString terminal
@@ -782,14 +823,30 @@ AAA                 right                                                       
 
             // First render: 50/50 split
             let mutable state =
-                App.pumpOnce worldFreezer true (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    true
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             // Send keystroke to trigger rebalance
             world.SendKey (ConsoleKeyInfo ('x', ConsoleKey.NoName, false, false, false))
 
             // Second render: 25/75 split
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             let secondRender = ConsoleHarness.toString terminal
 
@@ -841,7 +898,15 @@ AAA                 right                                                       
 
             // First render: 70/30 split with X's on the left
             let mutable state =
-                App.pumpOnce worldFreezer true (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    true
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             ConsoleHarness.toString terminal |> shouldContainText "XXXX"
 
@@ -850,7 +915,15 @@ AAA                 right                                                       
 
             // Second render: 30/70 split
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             let secondRender = ConsoleHarness.toString terminal
 
@@ -930,6 +1003,7 @@ AAA                 right                                                       
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             // Expected behavior after fix:
@@ -1001,6 +1075,7 @@ small               ┌──────────────────┐
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             // Left should expand to fill most of the space, Right should be exactly 5 chars wide
@@ -1055,6 +1130,7 @@ Left                               Right|
                 processWorld
                 vdomAuto
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             // Now test panelSplitAutoExpand
@@ -1076,6 +1152,7 @@ Left                               Right|
                 processWorld
                 vdomExpand
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             // With panelSplitAuto, excess is distributed proportionally by preferred width
@@ -1146,6 +1223,7 @@ Left                               Right|
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             // Both Top and Bottom have max height of 1, so each gets exactly 1 row.
@@ -1213,6 +1291,7 @@ Bottom              |
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             // Each should get exactly their preferred width: Left=4, Right=5
@@ -1277,6 +1356,7 @@ LeftRight                               |
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             // Second child should be clamped to 1 row despite wanting all excess
@@ -1349,7 +1429,15 @@ Bottom              |
 
             // First render with content
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -1368,7 +1456,15 @@ Line3               |
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
 
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             // "Line2" and "Line3" should be cleared, only "OnlyThis" remains
             expect {
@@ -1480,6 +1576,7 @@ OnlyThis            |
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             // First child should be clamped to 12 columns (its maxWidth)
@@ -1584,6 +1681,7 @@ LLLLLLLLLLLLRRRRRRRR|
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             // First child should be clamped to 2 rows (its maxHeight)

--- a/WoofWare.Zoomies.Test/TestProgressBar.fs
+++ b/WoofWare.Zoomies.Test/TestProgressBar.fs
@@ -44,7 +44,15 @@ module TestProgressBar =
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -82,7 +90,15 @@ module TestProgressBar =
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -120,7 +136,15 @@ module TestProgressBar =
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -162,7 +186,15 @@ module TestProgressBar =
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -202,7 +234,15 @@ Loading:[███░░░░░░░] 30%      |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -246,7 +286,15 @@ Loading:[███░░░░░░░] 30%      |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -288,7 +336,15 @@ Progress:[██████░░░░]         |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -326,7 +382,15 @@ Progress:[██████░░░░]         |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
             |> ignore
 
             expect {
@@ -369,7 +433,15 @@ Progress:[██████░░░░]         |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -407,7 +479,15 @@ Progress:[██████░░░░]         |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot

--- a/WoofWare.Zoomies.Test/TestRender.fs
+++ b/WoofWare.Zoomies.Test/TestRender.fs
@@ -140,7 +140,15 @@ module TestRender =
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -164,7 +172,15 @@ module TestRender =
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
 
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -188,7 +204,15 @@ module TestRender =
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
 
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -212,7 +236,15 @@ module TestRender =
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
 
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -236,7 +268,15 @@ only displayed when checked                this one is focusable!               
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
 
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -260,7 +300,15 @@ only displayed when checked                this one is focusable!               
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
 
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -284,7 +332,15 @@ only displayed when checked                this one is focusable!               
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
 
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -308,7 +364,15 @@ only displayed when checked                this one is focusable!               
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
 
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -332,7 +396,15 @@ only displayed when checked                this one is focusable!               
             world.SendKey (ConsoleKeyInfo (' ', ConsoleKey.Spacebar, false, false, false))
 
             state <-
-                App.pumpOnce worldFreezer state (fun _ -> true) renderState processWorld vdom ActivationResolver.none
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    (fun _ -> true)
+                    renderState
+                    processWorld
+                    vdom
+                    ActivationResolver.none
+                    (fun () -> false)
 
             expect {
                 snapshot

--- a/WoofWare.Zoomies.Test/TestTable.fs
+++ b/WoofWare.Zoomies.Test/TestTable.fs
@@ -46,7 +46,15 @@ module TestTable =
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -93,7 +101,15 @@ module TestTable =
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -141,7 +157,15 @@ A2B2                |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -188,7 +212,15 @@ Bob  25                       |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -235,7 +267,15 @@ A2        B2        |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -283,7 +323,15 @@ A        B                    |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -339,7 +387,15 @@ Row3                     |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -388,7 +444,15 @@ A    B                        |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -436,7 +500,15 @@ A           B       |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -478,7 +550,15 @@ XY                  |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -528,7 +608,15 @@ Single              |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -583,7 +671,15 @@ Row3                |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -638,7 +734,15 @@ Bottom              |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -693,7 +797,15 @@ Prop                |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -739,7 +851,15 @@ Row2                |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -792,7 +912,15 @@ Cell2               |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -843,7 +971,15 @@ X    Y                        |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -894,7 +1030,15 @@ Data1   Data2  |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -950,7 +1094,15 @@ A B                 |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -999,7 +1151,15 @@ Col1          Col2          C3|
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -1045,7 +1205,15 @@ A    B C                      |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -1093,7 +1261,15 @@ X  Y                |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             // After sanitization all become Column.Proportion 0.01, dividing space equally
             expect {
@@ -1147,7 +1323,15 @@ A         B         C         |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -1200,7 +1384,15 @@ X      Y       Z              |
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -1253,7 +1445,15 @@ gColumngColumnngColu|
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             expect {
                 snapshot
@@ -1596,6 +1796,7 @@ module TestTableMeasurements =
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore
 
             let output = ConsoleHarness.toString terminal
@@ -1720,7 +1921,15 @@ module TestTablePerformance =
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
             // Just verify it renders without throwing
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             // Verify first row rendered
             let output = ConsoleHarness.toString terminal
@@ -1762,7 +1971,15 @@ module TestTablePerformance =
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             let output = ConsoleHarness.toString terminal
             output |> shouldContainText "0"
@@ -1803,7 +2020,15 @@ module TestTablePerformance =
 
             let renderState = RenderState.make console MockTime.getStaticUtcNow None
 
-            App.pumpOnce worldFreezer () haveFrameworkHandleFocus renderState processWorld vdom ActivationResolver.none
+            App.pumpOnce
+                worldFreezer
+                ()
+                haveFrameworkHandleFocus
+                renderState
+                processWorld
+                vdom
+                ActivationResolver.none
+                (fun () -> false)
 
             let output = ConsoleHarness.toString terminal
             output |> shouldContainText "C0"

--- a/WoofWare.Zoomies.Test/TestTextBox.fs
+++ b/WoofWare.Zoomies.Test/TestTextBox.fs
@@ -102,7 +102,16 @@ module TestTextBox =
                 }
 
             // Initial render - textbox focused
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             expect {
                 snapshot
@@ -117,7 +126,17 @@ module TestTextBox =
 
             // Press Tab to move focus to button
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             // Verify textbox state is unchanged (Tab was not inserted as text)
             state.Content |> shouldEqual ""
@@ -178,19 +197,58 @@ module TestTextBox =
             let mutable state = ImmutableArray.Empty
 
             // Initial render
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             // Press Tab
             world.SendKey (ConsoleKeyInfo ('\t', ConsoleKey.Tab, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             // Press 'a'
             world.SendKey (ConsoleKeyInfo ('a', ConsoleKey.A, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             // Press Backspace
             world.SendKey (ConsoleKeyInfo ('\b', ConsoleKey.Backspace, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             // Verify all three keystrokes reached ProcessWorld
             state
@@ -253,46 +311,115 @@ module TestTextBox =
                 }
 
             // Initial render
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             // Type 'H' (Shift+h)
             world.SendKey (ConsoleKeyInfo ('H', ConsoleKey.H, true, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "H"
             state.Cursor |> shouldEqual 1
 
             // Type 'e'
             world.SendKey (ConsoleKeyInfo ('e', ConsoleKey.E, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "He"
             state.Cursor |> shouldEqual 2
 
             // Type 'l'
             world.SendKey (ConsoleKeyInfo ('l', ConsoleKey.L, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "Hel"
             state.Cursor |> shouldEqual 3
 
             // Type 'l'
             world.SendKey (ConsoleKeyInfo ('l', ConsoleKey.L, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "Hell"
             state.Cursor |> shouldEqual 4
 
             // Type 'o'
             world.SendKey (ConsoleKeyInfo ('o', ConsoleKey.O, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "Hello"
             state.Cursor |> shouldEqual 5
 
             // Type '!' (Shift+1)
             world.SendKey (ConsoleKeyInfo ('!', ConsoleKey.D1, true, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "Hello!"
             state.Cursor |> shouldEqual 6
@@ -363,41 +490,110 @@ Hello!|                                 |
                 }
 
             // Initial render
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             // Press Backspace
             world.SendKey (ConsoleKeyInfo ('\b', ConsoleKey.Backspace, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "Hell"
             state.Cursor |> shouldEqual 4
 
             // Move cursor to 1 (between 'H' and 'e')
             world.SendKey (ConsoleKeyInfo ('\000', ConsoleKey.Home, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             world.SendKey (ConsoleKeyInfo ('\000', ConsoleKey.RightArrow, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Cursor |> shouldEqual 1
 
             // Press Delete (should delete 'e')
             world.SendKey (ConsoleKeyInfo ('\000', ConsoleKey.Delete, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "Hll"
             state.Cursor |> shouldEqual 1
 
             // Press Backspace (should delete 'H')
             world.SendKey (ConsoleKeyInfo ('\b', ConsoleKey.Backspace, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "ll"
             state.Cursor |> shouldEqual 0
 
             // Press Backspace again (should do nothing, at start)
             world.SendKey (ConsoleKeyInfo ('\b', ConsoleKey.Backspace, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "ll"
             state.Cursor |> shouldEqual 0
@@ -457,46 +653,115 @@ Hello!|                                 |
                 }
 
             // Initial render
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             // Press Left
             world.SendKey (ConsoleKeyInfo ('\000', ConsoleKey.LeftArrow, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "Hello"
             state.Cursor |> shouldEqual 4
 
             // Press Left
             world.SendKey (ConsoleKeyInfo ('\000', ConsoleKey.LeftArrow, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "Hello"
             state.Cursor |> shouldEqual 3
 
             // Press Home
             world.SendKey (ConsoleKeyInfo ('\000', ConsoleKey.Home, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "Hello"
             state.Cursor |> shouldEqual 0
 
             // Press Right
             world.SendKey (ConsoleKeyInfo ('\000', ConsoleKey.RightArrow, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "Hello"
             state.Cursor |> shouldEqual 1
 
             // Press End
             world.SendKey (ConsoleKeyInfo ('\000', ConsoleKey.End, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "Hello"
             state.Cursor |> shouldEqual 5
 
             // Press Right (should do nothing, at end)
             world.SendKey (ConsoleKeyInfo ('\000', ConsoleKey.RightArrow, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "Hello"
             state.Cursor |> shouldEqual 5
@@ -581,7 +846,16 @@ Hello!|                                 |
                 }
 
             // Initial render - textbox1 focused
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             // Note: This test verifies cursor position only. Style verification (CellStyle.inverted)
             // is not tested because ConsoleHarness doesn't capture styling information.
@@ -672,11 +946,30 @@ Unfocused                               |
                 }
 
             // Initial render
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             // Press Delete (should do nothing, cursor is at end)
             world.SendKey (ConsoleKeyInfo ('\000', ConsoleKey.Delete, false, false, false))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "Hello"
             state.Cursor |> shouldEqual 5
@@ -737,7 +1030,16 @@ Unfocused                               |
                 }
 
             // Initial render
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             // Send multiple keystrokes before next pump
             world.SendKey (ConsoleKeyInfo ('H', ConsoleKey.H, true, false, false))
@@ -745,7 +1047,16 @@ Unfocused                               |
             world.SendKey (ConsoleKeyInfo ('!', ConsoleKey.D1, true, false, false))
 
             // Process all events in one batch
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             // All three characters should be inserted
             state.Content |> shouldEqual "Hi!"
@@ -806,18 +1117,47 @@ Unfocused                               |
                 }
 
             // Initial render
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             // Press Ctrl+A (beginning of line)
             world.SendKey (ConsoleKeyInfo ('\001', ConsoleKey.A, false, false, true))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "Hello World"
             state.Cursor |> shouldEqual 0
 
             // Press Ctrl+E (end of line)
             world.SendKey (ConsoleKeyInfo ('\005', ConsoleKey.E, false, false, true))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "Hello World"
             state.Cursor |> shouldEqual 11
@@ -877,17 +1217,46 @@ Unfocused                               |
                 }
 
             // Initial render
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             // Press Ctrl+B (backward)
             world.SendKey (ConsoleKeyInfo ('\002', ConsoleKey.B, false, false, true))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Cursor |> shouldEqual 2
 
             // Press Ctrl+F (forward)
             world.SendKey (ConsoleKeyInfo ('\006', ConsoleKey.F, false, false, true))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Cursor |> shouldEqual 3
         }
@@ -946,18 +1315,47 @@ Unfocused                               |
                 }
 
             // Initial render
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             // Press Ctrl+D (delete char at cursor, should delete 'l')
             world.SendKey (ConsoleKeyInfo ('\004', ConsoleKey.D, false, false, true))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "Helo"
             state.Cursor |> shouldEqual 2
 
             // Press Ctrl+H (backspace, should delete 'e')
             world.SendKey (ConsoleKeyInfo ('\008', ConsoleKey.H, false, false, true))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "Hlo"
             state.Cursor |> shouldEqual 1
@@ -1017,11 +1415,30 @@ Unfocused                               |
                 }
 
             // Initial render
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             // Press Ctrl+K (kill to end)
             world.SendKey (ConsoleKeyInfo ('\011', ConsoleKey.K, false, false, true))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "Hello"
             state.Cursor |> shouldEqual 5
@@ -1081,11 +1498,30 @@ Unfocused                               |
                 }
 
             // Initial render
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             // Press Ctrl+U (kill to beginning)
             world.SendKey (ConsoleKeyInfo ('\021', ConsoleKey.U, false, false, true))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "World"
             state.Cursor |> shouldEqual 0
@@ -1145,18 +1581,47 @@ Unfocused                               |
                 }
 
             // Initial render
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             // Press Ctrl+W (delete word backward, should delete "World")
             world.SendKey (ConsoleKeyInfo ('\023', ConsoleKey.W, false, false, true))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual "Hello  Test"
             state.Cursor |> shouldEqual 6
 
             // Press Ctrl+W again (should delete "Hello")
             world.SendKey (ConsoleKeyInfo ('\023', ConsoleKey.W, false, false, true))
-            state <- App.pumpOnce worldFreezer state haveFrameworkHandleFocus renderState processWorld vdom resolver
+
+            state <-
+                App.pumpOnce
+                    worldFreezer
+                    state
+                    haveFrameworkHandleFocus
+                    renderState
+                    processWorld
+                    vdom
+                    resolver
+                    (fun () -> false)
 
             state.Content |> shouldEqual " Test"
             state.Cursor |> shouldEqual 0

--- a/WoofWare.Zoomies.Test/TestTextRendering.fs
+++ b/WoofWare.Zoomies.Test/TestTextRendering.fs
@@ -65,6 +65,7 @@ module TestTextRendering =
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
         }
 
@@ -123,6 +124,7 @@ module TestTextRendering =
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
         }
 
@@ -168,6 +170,7 @@ module TestTextRendering =
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {
@@ -222,6 +225,7 @@ bottom    |
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {
@@ -271,6 +275,7 @@ Line3               |
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {
@@ -320,6 +325,7 @@ Line3               |
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {
@@ -369,6 +375,7 @@ Line3               |
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {
@@ -432,6 +439,7 @@ Line3               |
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             // All 5 lines of text should be visible, plus the footer
@@ -493,6 +501,7 @@ Footer              |
                 processWorld
                 vdom
                 ActivationResolver.none
+                (fun () -> false)
             |> ignore<FakeUnit>
 
             expect {


### PR DESCRIPTION
Add an isCancelled callback parameter to processChanges and pumpOnce that is checked on each iteration of the batch processing loop. This allows Ctrl+C to interrupt event processing mid-batch rather than having to wait for all pasted characters to be processed before the main loop can check the cancellation flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)